### PR TITLE
feat: reset time interval values when deleting the last remaining int…

### DIFF
--- a/src/features/time/hooks/use-time-intervals/index.ts
+++ b/src/features/time/hooks/use-time-intervals/index.ts
@@ -20,7 +20,13 @@ export const useTimeIntervals = () => {
   };
 
   const onDeleteTimeInterval = (id: string) => {
-    setTimeIntervals(timeIntervals.filter((interval) => interval.id !== id));
+    if (timeIntervals.length === 1) {
+      // If only one interval exists, reset its values instead of deleting
+      setTimeIntervals([{ id: crypto.randomUUID(), start: "", end: "" }]);
+    } else {
+      // If multiple intervals exist, delete the specified one
+      setTimeIntervals(timeIntervals.filter((interval) => interval.id !== id));
+    }
   };
 
   const onAddTimeInterval = () => {


### PR DESCRIPTION
…erval

Instead of deleting the last time interval and leaving an empty state, the delete action now resets the interval values to empty strings. This improves UX by ensuring there''s always at least one interval available for user input.

Fixes #58

resolve: #

## 変更点
