### PR TITLE
feat: reset time interval values when deleting last interval

### DIFF
--- a/src/features/time/hooks/use-time-intervals/index.ts
+++ b/src/features/time/hooks/use-time-intervals/index.ts
@@ -20,7 +20,13 @@ export const useTimeIntervals = () => {
   };
 
   const onDeleteTimeInterval = (id: string) => {
-    setTimeIntervals(timeIntervals.filter((interval) => interval.id !== id));
+    if (timeIntervals.length === 1) {
+      // If only one interval exists, reset its values instead of deleting
+      setTimeIntervals([{ id: crypto.randomUUID(), start: "", end: "" }]);
+    } else {
+      // If multiple intervals exist, delete the specified one
+      setTimeIntervals(timeIntervals.filter((interval) => interval.id !== id));
+    }
   };
 
   const onAddTimeInterval = () => {


### PR DESCRIPTION
Implements the requested UX improvement where deleting the last remaining time interval resets its values instead of removing it entirely.

## Changes
- Modified `useTimeIntervals` hook to check if only one interval exists
- When one interval: reset values to empty strings
- When multiple: maintain existing deletion behavior

Fixes #58

Generated with [Claude Code](https://claude.ai/code)