### PR TITLE
style: convert React components to function declarations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ pnpm vitest run   # テストを一度だけ実行
 - プリコミットフックでコード品質を保証
 - TypeScript strictモードを強制
 - 既存のコードベースのパターンに従う
+- Reactコンポーネントはfunction宣言を使用（arrow functionではなく）
+- React.FCの代わりに、必要に応じてPropsの型注釈を使用
 
 ### UI開発
 - スタイリングにはTailwind CSSユーティリティを使用

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,7 +8,7 @@ import { TimeIntervalInput } from "./features/time/components/time-interval-inpu
 import { useTimeIntervals } from "./features/time/hooks/use-time-intervals";
 import { useTotalTime } from "./features/time/hooks/use-total-time";
 
-const App = () => {
+function App() {
   const {
     timeIntervals,
     hasValidTimeIntervals,
@@ -92,6 +92,6 @@ const App = () => {
       <Footer />
     </div>
   );
-};
+}
 
 export default App;

--- a/src/components/icons/logo.tsx
+++ b/src/components/icons/logo.tsx
@@ -1,12 +1,10 @@
-import type { FC } from "react";
-
 interface Props {
   width?: number;
   height?: number;
   className?: string;
 }
 
-export const Logo: FC<Props> = ({ width, height, className }) => {
+export function Logo({ width, height, className }: Props) {
   return (
     <img
       alt="logo icon"
@@ -16,4 +14,4 @@ export const Logo: FC<Props> = ({ width, height, className }) => {
       className={className}
     />
   );
-};
+}

--- a/src/components/layouts/footer/index.tsx
+++ b/src/components/layouts/footer/index.tsx
@@ -1,4 +1,4 @@
-export const Footer = () => {
+export function Footer() {
   return (
     <footer className="bg-gray-100 border-t border-gray-200 mt-auto">
       <div className="container mx-auto px-4 py-6">
@@ -16,4 +16,4 @@ export const Footer = () => {
       </div>
     </footer>
   );
-};
+}

--- a/src/components/layouts/header/index.tsx
+++ b/src/components/layouts/header/index.tsx
@@ -1,6 +1,6 @@
 import { Logo } from "@/components/icons/logo";
 
-export const Header = () => {
+export function Header() {
   return (
     <header className="bg-gradient-to-r from-blue-50 to-blue-100 border-b border-blue-200">
       <div className="container mx-auto px-4 py-4 sm:py-6">
@@ -20,4 +20,4 @@ export const Header = () => {
       </div>
     </header>
   );
-};
+}

--- a/src/features/time/components/time-interval-input/index.tsx
+++ b/src/features/time/components/time-interval-input/index.tsx
@@ -1,5 +1,4 @@
 import { Label } from "@radix-ui/react-label";
-import type { FC } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,11 +11,11 @@ interface Props {
   onDeleteTimeInterval: (id: string) => void;
 }
 
-export const TimeIntervalInput: FC<Props> = ({
+export function TimeIntervalInput({
   timeInterval,
   onChangeTimeInterval,
   onDeleteTimeInterval,
-}) => {
+}: Props) {
   return (
     <div className="flex flex-row gap-2 sm:gap-3 items-end p-3 sm:p-4 bg-blue-50 rounded-lg border border-blue-100">
       <div className="flex-1">
@@ -69,4 +68,4 @@ export const TimeIntervalInput: FC<Props> = ({
       </Button>
     </div>
   );
-};
+}


### PR DESCRIPTION
## Summary
- Convert all React components from arrow functions to function declarations
- Remove React.FC type annotations 
- Update CLAUDE.md coding style guide to reflect new conventions

## Changes
- `src/app.tsx`: Convert App component
- `src/components/layouts/header/index.tsx`: Convert Header component
- `src/components/layouts/footer/index.tsx`: Convert Footer component
- `src/components/icons/logo.tsx`: Convert Logo component and remove FC import
- `src/features/time/components/time-interval-input/index.tsx`: Convert TimeIntervalInput component and remove FC import
- `CLAUDE.md`: Add coding style guidelines for React components

## Test plan
- [x] Run format and lint commands - all passing
- [ ] Verify application still works correctly
- [ ] Check that all components render as expected

Resolves #283

🤖 Generated with [Claude Code](https://claude.ai/code)